### PR TITLE
Probably incorrect integration name

### DIFF
--- a/docs/modules/ROOT/pages/kamelets/kamelets-dev.adoc
+++ b/docs/modules/ROOT/pages/kamelets/kamelets-dev.adoc
@@ -580,7 +580,7 @@ with all the advantages that derive from a point of view of performance and reso
 
 If we managed to reduce our integration to contain only a Camel route, converting it to YAML is straightforward:
 
-.earthquake-source.kamelet.yaml
+.earthquake.yaml
 [source,yaml]
 ----
 # camel-k: language=yaml property=period=20000 property=lookAhead=120 dependency=camel-quarkus:caffeine dependency=camel-quarkus:http


### PR DESCRIPTION
Yaml integration source is called "earthquake-source.kamelet.yaml", but I assume there should be "earthquake.yaml", as the section ends with "kamel local run earthquake.yaml"

<!-- Description -->




<!--
Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". 

You can (optionally) mark this PR with labels "kind/bug" or "kind/feature" to make sure
the text is added to the right section of the release notes. 
-->

**Release Note**
```release-note
NONE
```
